### PR TITLE
configurable behaviour for boundary cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,25 @@ Alternatively, you can use a filter function to specify the output. You have acc
 - idem for the second edge: `ring1`, `edge1`, `start1`, `end1`, `frac1`
 - boolean indicating if the intersection is unique: `unique`
 
-Finally, you can set a boolean variable to specify if a spatial index should be used to filter for possible intersections.
+Finally, you can pass an option object to control the behaviour of the algorithm.
+The following options are supported:
+
+|Option|Description|
+|------|-----------|
+| `useSpatialIndex` | Whether a spatial index should be used to filter for possible intersections. Default: `true` |
+| `reportVertexOnVertex` | If the same vertex (or almost the same vertex) appears more than once in the input, should this be reported as an intersection? Default: `false`|
+| `reportVertexOnEdge` | If a vertex lies (almost) exactly on an edge segment, should this be reported as an intersection? Default: `false` |
+| `epsilon` | It is almost never a good idea to compare floating point numbers for identity. Therefor, if we say "the same vertex" or "exactly on an edge segment", we need to define how "close" is "close enough". Note that the value is *not* used as an euclidian distance but always relative to the length of some edge segment. Default: `0.0000001`|
 
 Together, this may look like so:
 
 ```javascript
-var useSpatialIndex = 0;
-var isects = gpsi(poly, function filterFn(isect, ring0, edge0, start0, end0, frac0, ring1, edge1, start1, end1, frac1, unique){return [isect, frac0, frac1];}, useSpatialIndex);
+var options = {
+  useSpatialIndex:false
+};
+var isects = gpsi(poly, function filterFn(isect, ring0, edge0, start0, end0, frac0, ring1, edge1, start1, end1, frac1, unique){return [isect, frac0, frac1];}, options);
 
 // isects = [[[5, 8], 0.4856, 0.1865]], [[[7, 3], 0.3985, 0.9658]], ...]
 ```
+For backwards compatibility, if you pass anything other than an object, it will be interpreted as the value of the
+`useSpatialIndex`-option.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following options are supported:
 | `useSpatialIndex` | Whether a spatial index should be used to filter for possible intersections. Default: `true` |
 | `reportVertexOnVertex` | If the same vertex (or almost the same vertex) appears more than once in the input, should this be reported as an intersection? Default: `false`|
 | `reportVertexOnEdge` | If a vertex lies (almost) exactly on an edge segment, should this be reported as an intersection? Default: `false` |
-| `epsilon` | It is almost never a good idea to compare floating point numbers for identity. Therefor, if we say "the same vertex" or "exactly on an edge segment", we need to define how "close" is "close enough". Note that the value is *not* used as an euclidian distance but always relative to the length of some edge segment. Default: `0.0000001`|
+| `epsilon` | It is almost never a good idea to compare floating point numbers for identity. Therefor, if we say "the same vertex" or "exactly on an edge segment", we need to define how "close" is "close enough". Note that the value is *not* used as an euclidian distance but always relative to the length of some edge segment. Default: `0`|
 
 Together, this may look like so:
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ module.exports = function(feature, filterFn, options0) {
   }
 
   if (feature.geometry.type != "Polygon") throw new Error("The input feature must be a Polygon");
-  if (useSpatialIndex == undefined) useSpatialIndex = 1;
 
   var coord = feature.geometry.coordinates;
 
@@ -72,7 +71,7 @@ module.exports = function(feature, filterFn, options0) {
   return output;
 
   // true if frac is (almost) 1.0 or 0.0
-  var isBoundaryCase = function(frac){
+  function isBoundaryCase(frac){
     var e2 = options.epsilon * options.epsilon;
     return e2 >= (frac-1)*(frac-1) || e2 >= frac*frac;
   };

--- a/index.js
+++ b/index.js
@@ -74,7 +74,10 @@ module.exports = function(feature, filterFn, options0) {
   function isBoundaryCase(frac){
     var e2 = options.epsilon * options.epsilon;
     return e2 >= (frac-1)*(frac-1) || e2 >= frac*frac;
-  };
+  }
+  function isOutside(frac){
+    return frac < 0 - options.epsilon || frac > 1 + options.epsilon;
+  }
   // Function to check if two edges intersect and add the intersection to the output
   function ifIsectAddToOutput(ring0, edge0, ring1, edge1) {
     var start0 = coord[ring0][edge0];
@@ -99,7 +102,9 @@ module.exports = function(feature, filterFn, options0) {
 
     // There are roughly three cases we need to deal with.
     // 1. If at least one of the fracs lies outside [0,1], there is no intersection.
-    if (frac0 > 1 || frac0 < 0 || frac1 > 1 || frac1 < 0) return; // require segment intersection
+    if (isOutside(frac0) || isOutside(frac1)) {
+      return; // require segment intersection
+    }
 
     // 2. If both are either exactly 0 or exactly 1, this is not an intersection but just
     // two edge segments sharing a common vertex.
@@ -107,7 +112,7 @@ module.exports = function(feature, filterFn, options0) {
       if(! options.reportVertexOnVertex) return;
     }
 
-    //  If only one of the fractions is exactly 0 or 1, this is
+    // 3. If only one of the fractions is exactly 0 or 1, this is
     // a vertex-on-edge situation.
     if (isBoundaryCase(frac0) || isBoundaryCase(frac1)){
       if(! options.reportVertexOnEdge) return;

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var merge = function(){
 };
 defaults = {
   useSpatialIndex: true,
-  epsilon: 0.0000001,
+  epsilon: 0,
   reportVertexOnVertex: false,
   reportVertexOnEdge: false
 };

--- a/index.js
+++ b/index.js
@@ -1,21 +1,31 @@
 // Find self-intersections in geojson polygon (possibly with interior rings)
 var rbush = require('rbush');
-var EPSILON = 0.0000001; //TODO: should be configurable!
 
-// true if frac is (almost) 1.0 or 0.0
-var isBoundaryCase = function(frac){
-  var e2 = EPSILON * EPSILON;
-  return e2 >= (frac-1)*(frac-1) || e2 >= frac*frac;
+
+var merge = function(){
+  var output = {};
+  Array.prototype.slice.call(arguments).forEach(function(arg){
+    if(arg){
+      Object.keys(arg).forEach(function(key){
+        output[key]=arg[key];
+      });
+    }
+  });
+  return output;
+};
+defaults = {
+  useSpatialIndex: true,
+  epsilon: 0.0000001,
+  reportVertexOnVertex: false,
+  reportVertexOnEdge: false
 };
 
-//TODO: might make sense to put `filterFn`, `useSpatialInde`, etc. 
-//      in an `options` object. But this breaks API compatibility.
-module.exports = function(feature, filterFn, options) {
-  var useSpatialIndex;
-  if("object" !== typeof options){
-    useSpatialIndex = !!options;
+module.exports = function(feature, filterFn, options0) {
+  var options;
+  if("object" === typeof options0){
+    options = merge(defaults,options0);
   } else {
-    useSpatialIndex = !!options.useSpatialIndex;
+    options = merge(defaults,{useSpatialIndex:options0});
   }
 
   if (feature.geometry.type != "Polygon") throw new Error("The input feature must be a Polygon");
@@ -26,7 +36,7 @@ module.exports = function(feature, filterFn, options) {
   var output = [];
   var seen = {};
 
-  if (useSpatialIndex) {
+  if (options.useSpatialIndex) {
     var allEdgesAsRbushTreeItems = [];
     for (var ring0 = 0; ring0 < coord.length; ring0++) {
       for (var edge0 = 0; edge0 < coord[ring0].length-1; edge0++) {
@@ -39,7 +49,7 @@ module.exports = function(feature, filterFn, options) {
 
   for (var ring0 = 0; ring0 < coord.length; ring0++) {
     for (var edge0 = 0; edge0 < coord[ring0].length-1; edge0++) {
-      if (useSpatialIndex) {
+      if (options.useSpatialIndex) {
         var bboxOverlaps = tree.search(rbushTreeItem(ring0, edge0));
         bboxOverlaps.forEach(function(bboxIsect) {
           var ring1 = bboxIsect.ring;
@@ -61,6 +71,11 @@ module.exports = function(feature, filterFn, options) {
   if (!filterFn) output = {type: "Feature", geometry: {type: "MultiPoint", coordinates: output}};
   return output;
 
+  // true if frac is (almost) 1.0 or 0.0
+  var isBoundaryCase = function(frac){
+    var e2 = options.epsilon * options.epsilon;
+    return e2 >= (frac-1)*(frac-1) || e2 >= frac*frac;
+  };
   // Function to check if two edges intersect and add the intersection to the output
   function ifIsectAddToOutput(ring0, edge0, ring1, edge1) {
     var start0 = coord[ring0][edge0];
@@ -86,20 +101,19 @@ module.exports = function(feature, filterFn, options) {
     // There are roughly three cases we need to deal with.
     // 1. If at least one of the fracs lies outside [0,1], there is no intersection.
     if (frac0 > 1 || frac0 < 0 || frac1 > 1 || frac1 < 0) return; // require segment intersection
-    
+
     // 2. If both are either exactly 0 or exactly 1, this is not an intersection but just
-    // two edge segments sharing a common vertex. 
+    // two edge segments sharing a common vertex.
     if (isBoundaryCase(frac0) && isBoundaryCase(frac1)){
       if(! options.reportVertexOnVertex) return;
     }
 
     //  If only one of the fractions is exactly 0 or 1, this is
-    // a vertex-on-edge situation. 
-    // Maybe interesting to report this as an intersection, depending on the application.
+    // a vertex-on-edge situation.
     if (isBoundaryCase(frac0) || isBoundaryCase(frac1)){
       if(! options.reportVertexOnEdge) return;
     }
-    //
+
     var key = isect;
     var unique = !seen[key];
     if (unique) {


### PR DESCRIPTION
Hi,

This PR adds support for configuring how the library deals with boundary cases (edge-on-vertex, vertex-on-vertex). For each, you can now configure if such cases should be reported as an intersection.
By default, the behavior is as it used to be. 

See updated README.md for details.

To the best of my knowledge this change should be 100% backwards compatible.

Let me know if there are any issues keeping this from being merged. I'm happy to help (if I can).

