### PR TITLE
Fix es2015 compilation error

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var merge = function(){
   });
   return output;
 };
-defaults = {
+var defaults = {
   useSpatialIndex: true,
   epsilon: 0,
   reportVertexOnVertex: false,


### PR DESCRIPTION
Hi @mclaeysb 

Great small library you have built here! 

We are using your simplepolygon library to split up self intersecting polygons on our front end. Unfortunately as we are moving to [ES2015](https://babeljs.io/docs/en/learn/), geojson-polygon-self-intersections is not able to run anymore without errors.
As it is a simple fix, I hope you can merge it and update `geojson-polygon-self-intersections` and `simplepolygon` on npm.

Just tell me if you are too busy. I will then just fork the projects and create two new npm projects with the updated code.

Best regards

Severin
