### PR TITLE
Bump rbush to 3.0.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function(feature, filterFn, options0) {
         allEdgesAsRbushTreeItems.push(rbushTreeItem(ring0, edge0))
       }
     }
-    var tree = rbush();
+    var tree = new rbush();
     tree.load(allEdgesAsRbushTreeItems);
   }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/mclaeysb/geojson-polygon-self-intersections/issues"
   },
   "dependencies": {
-    "rbush": "^2.0.1"
+    "rbush": "3.0.1"
   },
   "devDependencies": {},
   "homepage": "https://github.com/mclaeysb/geojson-polygon-self-intersections#readme"


### PR DESCRIPTION
Hello! This PR aims to bring rbush up to the latest version, in turn fixing bundling issues with bundlers such as Webpack and Vite. This is an upstream issue for us on the `turf` project. This in theory is just a small change to bumping the package.json to use `rbush` 3.0.1 and to use `new` instead of just accessing the function directly (the rbush module has been rewritten as ESM).